### PR TITLE
Set up socket permissions correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,14 @@ runs:
     - name: Initialise LXD
       shell: bash
       run: |
-        set -x
         sudo lxd waitready
         sudo lxd init --auto
-        sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        lxc network set lxdbr0 ipv6.address none
+
+    - name: Set up permissions for socket
+      shell: bash
+      run: |
+        sudo snap set lxd daemon.group=adm
+        sudo snap restart lxd
 
     - name: Configure firewall
       shell: bash


### PR DESCRIPTION
Per advice from LXD team, use `snap set` to set socket permissions.

We also should not be disabling IPv6 by default.