### PR TITLE
Make LXD refresh optional (speed reason)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
         sudo snap install juju --channel=3.0/stable
         mkdir -p ~/.local/share
         mkdir -p ~/.ssh
-        sudo snap connect juju:ssh-public-keys
+        sudo snap connect juju:ssh-keys
 
     - name: Bootstrap
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # setup-lxd
 
-A GitHub Action installs and configures the LXD snap on a runner.
+A GitHub Action which installs and configures the LXD snap on a runner.
 
 It will default install LXD from the `latest/stable` snap channel.
 You can specify a different channel using the `channel` input

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A GitHub Action which installs and configures the LXD snap on a runner.
 
 By default, this action will install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
 
-The action will also refresh LXD if it is already installed on a runner from SNAP,
-it can be skipped using the option 'refresh: false'.
+The action will also refresh the LXD snap to the latest version in a channel
+(only if LXD is installed from snap).
+It can be skipped using the option `refresh: false`.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # setup-lxd
 
-A GitHub Action which installs and configures the LXD snap on a runner.
+A GitHub Action installs and configures the LXD snap on a runner.
 
-By default, this action will install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
+It will default install LXD from the `latest/stable` snap channel.
+You can specify a different channel using the `channel` input
+(see `snap info lxd` for a list of available channels).
+
+The action will also refresh LXD if it is already installed on a runner,
+it can be skipped using the option 'refresh: false'.
 
 ## Example usage
 
@@ -18,6 +23,7 @@ jobs:
       uses: canonical/setup-lxd@[sha]
       with:
         channel: 5.0/stable
+        refresh: false
 
     - name: Launch container
       run: |

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A GitHub Action which installs and configures the LXD snap on a runner.
 
-It will default install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
+By default, this action will install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
 
-The action will also refresh LXD if it is already installed on a runner,
+The action will also refresh LXD if it is already installed on a runner from SNAP,
 it can be skipped using the option 'refresh: false'.
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 A GitHub Action which installs and configures the LXD snap on a runner.
 
-It will default install LXD from the `latest/stable` snap channel.
-You can specify a different channel using the `channel` input
-(see `snap info lxd` for a list of available channels).
+It will default install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
 
 The action will also refresh LXD if it is already installed on a runner,
 it can be skipped using the option 'refresh: false'.

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         set -x
-        if snap info lxd | grep "installed"; then
+        if snap info lxd | grep "^installed"; then
           sudo snap refresh lxd --channel=${{ inputs.channel }}
         else
           sudo snap install lxd --channel=${{ inputs.channel }}

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
 
-    - name: Install LXD snap
+    - name: Install/refresh LXD snap
       shell: bash
       run: |
         set -x

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: 'latest/stable'
   refresh:
-    description: 'Refresh installed LXD from SNAP'
+    description: 'Refresh installed LXD from snap'
     required: false
     default: 'true'
 
@@ -22,20 +22,20 @@ runs:
           echo "LXD has been installed from package already."
 
         elif snap info lxd | grep "^installed"; then
-          echo "LXD has been installed from SNAP already."
+          echo "LXD has been installed from snap already."
 
           if ( "${{ inputs.refresh }}" == "true" ) ; then
-            echo "Updating LXD from SNAP (channel=${{ inputs.channel }})"
+            echo "Updating LXD from snap (channel=${{ inputs.channel }})"
             sudo snap refresh lxd --channel=${{ inputs.channel }}
           else
-            echo "Skipping LXD update from SNAP (due to refresh=${{ inputs.refresh }})"
+            echo "Skipping LXD update from snap (due to refresh=${{ inputs.refresh }})"
           fi
 
         elif which lxd; then
           echo "LXD is locally available (installed from sources)."
 
         else
-          echo "LXD is missing, installing from SNAP (channel=${{ inputs.channel }})."
+          echo "LXD is missing, installing from snap (channel=${{ inputs.channel }})."
           sudo snap install lxd --channel=${{ inputs.channel }}
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -5,19 +5,30 @@ inputs:
     description: 'Snap channel to install LXD from'
     required: false
     default: 'latest/stable'
+  refresh:
+    description: 'Refresh installed LXD from'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
   steps:
 
-    - name: Install/refresh LXD snap
+    - name: Install LXD snap
       shell: bash
       run: |
         set -x
         if snap info lxd | grep "^installed"; then
-          sudo snap refresh lxd --channel=${{ inputs.channel }}
+          echo "LXD has been installed already, nothing to do."
         else
           sudo snap install lxd --channel=${{ inputs.channel }}
+        fi
+
+    - name: Refresh LXD snap
+      shell: bash
+      run: |
+        if ( "${{ inputs.refresh }}" == "true" ) ; then
+          sudo snap refresh lxd --channel=${{ inputs.channel }}
         fi
 
     - name: Initialise LXD

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: 'latest/stable'
   refresh:
-    description: 'Refresh installed LXD from'
+    description: 'Refresh installed LXD from SNAP'
     required: false
     default: 'true'
 
@@ -18,17 +18,25 @@ runs:
       shell: bash
       run: |
         set -x
-        if snap info lxd | grep "^installed"; then
-          echo "LXD has been installed already, nothing to do."
-        else
-          sudo snap install lxd --channel=${{ inputs.channel }}
-        fi
+        if [ "$(dpkg-query -f "\${db:Status-Status} \${db:Status-Eflag}" -W lxd 2>/dev/null)" = "installed ok" ]; then
+          echo "LXD has been installed from package already."
 
-    - name: Refresh LXD snap
-      shell: bash
-      run: |
-        if ( "${{ inputs.refresh }}" == "true" ) ; then
-          sudo snap refresh lxd --channel=${{ inputs.channel }}
+        elif snap info lxd | grep "^installed"; then
+          echo "LXD has been installed from SNAP already."
+
+          if ( "${{ inputs.refresh }}" == "true" ) ; then
+            echo "Updating LXD from SNAP (channel=${{ inputs.channel }})"
+            sudo snap refresh lxd --channel=${{ inputs.channel }}
+          else
+            echo "Skipping LXD update from SNAP (due to refresh=${{ inputs.refresh }})"
+          fi
+
+        elif which lxd; then
+          echo "LXD is locally available (installed from sources)."
+
+        else
+          echo "LXD is missing, installing from SNAP (channel=${{ inputs.channel }})."
+          sudo snap install lxd --channel=${{ inputs.channel }}
         fi
 
     - name: Initialise LXD


### PR DESCRIPTION
Hi,

After migration from 'whywaita/setup-lxd' to 'canonical/setup-lxd' we noticed significant performance slows down (90x times),
see  https://github.com/canonical/mongodb-rock/pull/2#issuecomment-1377338493

TL;DR. LXD is already installed on GitHub 'ubuntu-latest' image, so 'whywaita/setup-lxd' did nothing spending ~10 seconds but  'canonical/setup-lxd' is always upgrading LXD which tooks ~15 minutes.

The PR proposes to make 'LXD refresh' optional (in a backward compatible way). Tnx!