### PR TITLE
No inputs disables snap install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
         sudo snap install juju --channel=3.0/stable
         mkdir -p ~/.local/share
         mkdir -p ~/.ssh
-        sudo snap connect juju:ssh-public-keys
+        sudo snap connect juju:ssh-keys
 
     - name: Bootstrap
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Test
+on: [push, pull_request, workflow_dispatch]
+jobs:
+
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: ./
+        with:
+          channel: latest/stable
+
+      - name: Launch container
+        run: |
+          lxc launch ubuntu:
+
+  channel:
+    name: Channel
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: ./
+        with:
+          channel: 5.0/stable
+
+      - name: Check LXD version
+        shell: bash
+        run: |
+          [[ $(lxd version) == 5.0* ]]
+
+      - name: Launch container
+        run: |
+          lxc launch ubuntu:
+
+  preinstalled:
+    name: Preinstalled
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: ./
+
+      - name: Check LXD version
+        shell: bash
+        run: |
+          [[ $(lxd version) == 4.0.9 ]]
+
+      - name: Launch container
+        run: |
+          lxc launch ubuntu:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 # setup-lxd
 
+*NB: this action is currently in alpha, breaking changes can occur at any time.
+Please pin a SHA or exact version in your CI.*
+
 A GitHub Action which installs and configures the LXD snap on a runner.
 
-By default, this action will install LXD from the `latest/stable` snap channel. You can specify a different channel using the `channel` input. (See `snap info lxd` for a list of available channels).
+When run with no inputs:
+```yaml
+uses: canonical/setup-lxd
+```
+this action will use the LXD snap pre-installed on the runner. If LXD is not
+installed, it will `sudo snap install lxd` from the default channel.
+
+You can specify a snap channel with the `channel` input:
+```yaml
+uses: canonical/setup-lxd
+with:
+  channel: 5.2/candidate
+```
+and then this action will install/refresh LXD from the specified channel.
 
 ## Example usage
 
 ```yaml
-name: "Example"
+name: "Install LXD 5.0"
 on: push
 jobs:
   job1:
@@ -15,9 +31,26 @@ jobs:
     steps:
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@[sha]
+      uses: canonical/setup-lxd@[version]
       with:
-        channel: 5.0/stable
+        channel: 5.0/stable  # installs LXD 5.0.x
+
+    - name: Launch container
+      run: |
+        lxc launch ubuntu:22.04 u1
+```
+
+```yaml
+name: "Configure pre-installed LXD"
+on: push
+jobs:
+  job1:
+    runs-on: ubuntu-22.04
+    steps:
+
+    - name: Setup LXD
+      uses: canonical/setup-lxd@[version]
+      # uses pre-installed LXD snap (v4.0.9)
 
     - name: Launch container
       run: |

--- a/action.yml
+++ b/action.yml
@@ -4,13 +4,21 @@ inputs:
   channel:
     description: 'Snap channel to install LXD from'
     required: false
-    default: 'latest/stable'
 
 runs:
   using: "composite"
   steps:
 
+    - name: Install LXD if not present
+      if: "${{ github.event.inputs.channel == '' }}"
+      shell: bash
+      run: |
+        if ! snap info lxd | grep "installed"; then
+          sudo snap install lxd
+        fi
+
     - name: Install/refresh LXD snap
+      if: "${{ github.event.inputs.channel != '' }}"
       shell: bash
       run: |
         set -x


### PR DESCRIPTION
If this action is invoked with no `channel` input, it will not attempt to refresh LXD from snap - so you can use the pre-installed LXD version.

Also added some more GitHub tests.