### PR TITLE
action: fix inputs for workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,13 @@ jobs:
       - name: Setup LXD
         uses: ./
         with:
-          channel: 5.0/stable
+          # use a channel that is not the default on ubuntu-latest
+          channel: 4.0/stable
 
       - name: Check LXD version
         shell: bash
         run: |
-          [[ $(lxd version) == 5.0* ]]
+          [[ $(lxd version) == 4.0* ]]
 
       - name: Launch container
         run: |

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
 
     - name: Install LXD if not present
-      if: "${{ github.event.inputs.channel == '' }}"
+      if: "${{ inputs.channel == '' }}"
       shell: bash
       run: |
         if ! snap info lxd | grep "installed"; then
@@ -18,7 +18,7 @@ runs:
         fi
 
     - name: Install/refresh LXD snap
-      if: "${{ github.event.inputs.channel != '' }}"
+      if: "${{ inputs.channel != '' }}"
       shell: bash
       run: |
         set -x


### PR DESCRIPTION
## Overview

The `channel` keyword is ignored.

## Reproducer

Using the following action ignores the `channel` keyword:
```yaml
      - name: Setup LXD
        uses: canonical/setup-lxd@ea57509243d3cf39f8ab926e021bb353947b01b5
        with:
          channel: latest/stable
```

I also reproduced this by forking this repo and letting the [default workflow run](https://github.com/mr-cal/setup-lxd/actions/runs/4948776447/jobs/8849981347#step:3:7).  

## Details

[This test](https://github.com/canonical/setup-lxd/blob/ea57509243d3cf39f8ab926e021bb353947b01b5/.github/workflows/test.yml#L22) passes, but it is a false positive.  `ubuntu-latest` is 22.04 and is preloaded with 5.0/stable. The test uses `with: channel: 5.0/stable`, so it doesn't verify if the `channel` keyword was used.  I changed the test to use `4.0/stable`, which is no longer the default on `ubuntu-latest`.

The root cause is that `inputs` is the correct context, not `github.events.inputs` (which only works on [manually-triggered workflows](https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/)). 