### PR TITLE
action: Use `latest/candidate` by default

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         channel:
         - { juju: '2.9', lxd: latest/stable }
-        - { juju: '3.0', lxd: latest/stable }
+        - { juju: '3', lxd: latest/stable }
 
     steps:
 
@@ -28,10 +28,10 @@ jobs:
       run: |
         sudo snap install juju --classic --channel=2.9/stable
 
-    - name: Install Juju 3.0
-      if: matrix.channel.juju == '3.0'
+    - name: Install Juju 3
+      if: matrix.channel.juju == '3'
       run: |
-        sudo snap install juju --channel=3.0/stable
+        sudo snap install juju --channel=3/stable
         mkdir -p ~/.local/share
         mkdir -p ~/.ssh
         sudo snap connect juju:ssh-keys

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
         uses: ./
         with:
           # use a channel that is not the default on ubuntu-latest
-          channel: 4.0/stable
+          channel: 5.21/candidate
 
       - name: Check LXD version
         shell: bash
         run: |
-          [[ $(lxd version) == 4.0* ]]
+          [[ $(lxd version) == 5.21* ]]
 
       - name: Launch container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,26 +42,6 @@ jobs:
         run: |
           lxc launch ubuntu:
 
-  preinstalled:
-    name: Preinstalled
-    runs-on: ubuntu-20.04
-    steps:
-
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup LXD
-        uses: ./
-
-      - name: Check LXD version
-        shell: bash
-        run: |
-          [[ $(lxd version) == 4.0.9 ]]
-
-      - name: Launch container
-        run: |
-          lxc launch ubuntu:
-
   latest-stable:
     name: Install latest/stable
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Install dependencies
-        run: |
-          sudo snap install yq
-
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -83,8 +79,13 @@ jobs:
         shell: bash
         run: |
           set -eux
-          LATEST_STABLE_VERSION=$(snap info lxd | yq '.channels.latest/stable' | awk -F'-' '{print $1}')
-          [[ $(lxd version) == $LATEST_STABLE_VERSION ]]
+          TRACKING="$(snap info lxd | awk '/^tracking: / {print $2}' | cut -d/ -f1,2)"
+          INSTALLED="$(snap info lxd | awk '/^installed: / {print $2}' | cut -d- -f1)"
+
+          [[ "${TRACKING}" == "latest/stable" ]]
+
+          # XXX: remove LTS before comparison: "5.21.1 LTS" -> "5.21.1"
+          [[ $(lxd version | cut -d " " -f1) == "${INSTALLED}" ]]
 
       - name: Launch container
         run: |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ When run with no inputs:
 ```yaml
 uses: canonical/setup-lxd
 ```
-this action will use the LXD snap pre-installed on the runner. If LXD is not
-installed, it will `sudo snap install lxd` from the default channel.
+this action will install or refresh the LXD snap using the `latest/candidate` channel.
 
 You can specify a snap channel with the `channel` input:
 ```yaml
@@ -33,24 +32,7 @@ jobs:
     - name: Setup LXD
       uses: canonical/setup-lxd@[version]
       with:
-        channel: latest/stable  # switch from distro's LTS channel to latest/stable
-
-    - name: Launch container
-      run: |
-        lxc launch ubuntu:22.04 u1
-```
-
-```yaml
-name: "Configure pre-installed LXD"
-on: push
-jobs:
-  job1:
-    runs-on: ubuntu-22.04
-    steps:
-
-    - name: Setup LXD
-      uses: canonical/setup-lxd@[version]
-      # uses pre-installed LXD snap (22.04 comes with 5.0/stable)
+        channel: latest/edge
 
     - name: Launch container
       run: |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can specify a snap channel with the `channel` input:
 ```yaml
 uses: canonical/setup-lxd
 with:
-  channel: 5.2/candidate
+  channel: 5.21/stable
 ```
 and then this action will install/refresh LXD from the specified channel.
 

--- a/action.yml
+++ b/action.yml
@@ -21,17 +21,16 @@ runs:
           sudo snap install lxd --channel=${{ inputs.channel }}
         fi
 
+    - name: Set up permissions for socket
+      shell: bash
+      run: |
+        sudo snap set lxd daemon.group=adm
+
     - name: Initialise LXD
       shell: bash
       run: |
         sudo lxd waitready
         sudo lxd init --auto
-
-    - name: Set up permissions for socket
-      shell: bash
-      run: |
-        sudo snap set lxd daemon.group=adm
-        sudo snap restart lxd
 
     - name: Configure firewall
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -2,27 +2,20 @@ name: 'Setup LXD'
 description: 'Install and configure LXD on the runner'
 inputs:
   channel:
+    default: 'latest/candidate'
     description: 'Snap channel to install LXD from'
     required: false
+    type: string
 
 runs:
   using: "composite"
   steps:
 
-    - name: Install LXD if not present
-      if: "${{ inputs.channel == '' }}"
-      shell: bash
-      run: |
-        if ! snap info lxd | grep "installed"; then
-          sudo snap install lxd
-        fi
-
     - name: Install/refresh LXD snap
-      if: "${{ inputs.channel != '' }}"
       shell: bash
       run: |
         set -x
-        if snap info lxd | grep "installed"; then
+        if snap list lxd; then
           sudo snap refresh lxd --channel=${{ inputs.channel }}
         else
           sudo snap install lxd --channel=${{ inputs.channel }}


### PR DESCRIPTION
The default snap channel for LXD was changed from `latest/stable` (feature
release) to `5.21/stable` (LTS release) on April 2024. With that change, a huge
majority of casual LXD users will simply land on the `5.21/stable` channel
meaning that very few will actually test the feature releases leading up to the
next LTS.

If few are testing those feature releases, what will eventually land in the
next LTS will be at higher risks of introducing regressions.

Switching this action to use `latest/candidate` should strike a good balance
between stability and QA needs for LXD. `latest/candidate` is heavily tested
but slightly more risky than the older `latest/stable` channel this action used
when a simple `snap install lxd` was equivalent to `snap install lxd
--channel=latest/stable`.

This slight risk increase is deemed OK as this action is used on CI instances
that are ephemeral in nature and where the consuming users generally want to
have early signs of problems.