### PR TITLE
action: make the group configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ uses: canonical/setup-lxd
 ```
 this action will install or refresh the LXD snap using the `latest/candidate` channel.
 
+You can specify a different `group` membership required to access LXD:
+```yaml
+uses: canonical/setup-lxd
+with:
+  group: lxd
+```
+and then users of that group will have full control over LXD.
+
 You can specify a snap channel with the `channel` input:
 ```yaml
 uses: canonical/setup-lxd

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: 'Snap channel to install LXD from'
     required: false
     type: string
+  group:
+    default: 'adm'
+    description: 'Name of the group that will have access to LXD'
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -24,7 +29,7 @@ runs:
     - name: Set up permissions for socket
       shell: bash
       run: |
-        sudo snap set lxd daemon.group=adm
+        sudo snap set lxd daemon.group=${{ inputs.group }}
 
     - name: Initialise LXD
       shell: bash


### PR DESCRIPTION
This is useful for non-GitHub hosted runners (like Canonical ones) where the running user isn't necessarily member of the `adm` group.