### PR TITLE
Handle case where docker not installed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,5 +45,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
-        sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        if sudo iptables -L DOCKER-USER; then
+          sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        fi


### PR DESCRIPTION
Docker is not guaranteed to be installed on a github runner.
Previously, if docker was not installed,
the configure firewall step failed because
DOCKER-USER iptables chain did not exist.
Fix that by only updating the firewall rules
if the DOCKER-USER chain exists.

Fixes: #19