### PR TITLE
action: Disable compression when storing images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
       run: |
         sudo lxd waitready
         sudo lxd init --auto
+        sudo lxc config set images.compression_algorithm none
 
     - name: Configure firewall
       shell: bash


### PR DESCRIPTION
The default compression (gzip) ismaking the image storing much slower (from 25MB/s to 250MB/s) for no much gain in an action usage.

In case it creates problems it can safely be disabled in an extra action step, so no need to add an extra input for this.

See (before): https://github.com/canonical/desktop-engineering/actions/runs/12918081628/job/36026063645
After: https://github.com/canonical/desktop-engineering/actions/runs/12918341238/job/36026741354