### PR TITLE
Add preseed input for action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,62 @@ jobs:
       - name: Launch container
         run: |
           lxc launch ubuntu-minimal:
+
+  preseed:
+    name: Preseed
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: ./
+        with:
+          # Preseed taken from running the lxd init interactively on a fresh
+          # noble install, keeping all default values (except for the config,
+          # where we set the compression_algorithm to none for performance
+          # reasons) and printing the preseed at the end
+          preseed: |
+            config:
+              images.compression_algorithm: none
+            networks:
+            - config:
+                ipv4.address: auto
+                ipv6.address: auto
+              description: ""
+              name: lxdbr0
+              type: ""
+              project: default
+            storage_pools:
+            - config:
+                size: 5GiB
+              description: ""
+              name: default
+              driver: zfs
+            storage_volumes: []
+            profiles:
+            - config: {}
+              description: ""
+              devices:
+                eth0:
+                  name: eth0
+                  network: lxdbr0
+                  type: nic
+                root:
+                  path: /
+                  pool: default
+                  type: disk
+              name: default
+            projects: []
+            cluster: null
+
+      # lxd --auto uses a dir storage pool by default, so check if we have zfs
+      - name: Check storage pool type
+        shell: bash
+        run: |
+          lxc storage show default | grep -xF 'driver: zfs'
+
+      - name: Launch container
+        run: |
+          lxc launch ubuntu-minimal:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ with:
 ```
 and then this action will install/refresh LXD from the specified channel.
 
+If you require more control over LXD's initalisation, you can also specify the
+preseed input:
+```yaml
+uses: canonical/setup-lxd@main
+with:
+  preseed: |
+    config:
+      core.https_address: 192.0.2.1:9999
+      images.auto_update_interval: 15
+    networks:
+    - name: lxdbr0
+      type: bridge
+      config:
+        ipv4.address: auto
+        ipv6.address: none
+```
+See the [Initialise LXD documentation](https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration)
+for more information.
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: 'Name of the group that will have access to LXD'
     required: false
     type: string
+  preseed:
+    default: ''
+    description: 'Preseed to use when initialising LXD'
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -37,10 +42,17 @@ runs:
 
     - name: Initialise LXD
       shell: bash
+      env:
+        # Use an environment variable to have correct quoting and escaping
+        INPUT_PRESEED: ${{ inputs.preseed }}
       run: |
         sudo lxd waitready
-        sudo lxd init --auto
-        sudo lxc config set images.compression_algorithm none
+        if [[ "${INPUT_PRESEED}" == "" ]]; then
+          sudo lxd init --auto
+          sudo lxc config set images.compression_algorithm none
+        else
+          sudo lxd init --preseed <<< "${INPUT_PRESEED}"
+        fi
 
     - name: Configure firewall
       shell: bash


### PR DESCRIPTION
Add the preseed input for the action, making it possible to fully customise how LXD is initialised.

Update the README to include documentation for this input.

Add a new test which uses this new input with lxd init. The preseed for this test was obtained by running lxd init interactively on a fresh noble install and printing the preseed at the end.

This is something we would like to use in Anbox to tweak LXD in our test setup (e.g., use a ZFS storage pool).
Adding a preseed option should make it easy for anyone to tweak to their exact needs.