### PR TITLE
Simplify how IPv4 and IPv6 DOCKER-USER chains are detected

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,11 @@ runs:
         IFS=',' read -ra bridges <<< "${{ inputs.bridges }}"
         for i in "${bridges[@]}"; do
           bridge=$(echo "$i" | xargs)  # Trim whitespace
-          if sudo iptables -L DOCKER-USER; then
+          if sudo iptables -nL DOCKER-USER; then
             sudo iptables  -I DOCKER-USER -i "$bridge" -j ACCEPT
             sudo iptables  -I DOCKER-USER -o "$bridge" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
           fi
-          if sudo ip6tables -L DOCKER-USER; then
+          if sudo ip6tables -nL DOCKER-USER; then
             sudo ip6tables -I DOCKER-USER -i "$bridge" -j ACCEPT
             sudo ip6tables -I DOCKER-USER -o "$bridge" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
           fi

--- a/action.yml
+++ b/action.yml
@@ -63,15 +63,15 @@ runs:
       shell: bash
       run: |
         set -x
-        if sudo iptables -L DOCKER-USER; then
-          IFS=',' read -ra bridges <<< "${{ inputs.bridges }}"
-          for i in "${bridges[@]}"; do
-            bridge=$(echo "$i" | xargs)  # Trim whitespace
-            set +e
+        IFS=',' read -ra bridges <<< "${{ inputs.bridges }}"
+        for i in "${bridges[@]}"; do
+          bridge=$(echo "$i" | xargs)  # Trim whitespace
+          if sudo iptables -L DOCKER-USER; then
             sudo iptables  -I DOCKER-USER -i "$bridge" -j ACCEPT
-            sudo ip6tables -I DOCKER-USER -i "$bridge" -j ACCEPT
             sudo iptables  -I DOCKER-USER -o "$bridge" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+          fi
+          if sudo ip6tables -L DOCKER-USER; then
+            sudo ip6tables -I DOCKER-USER -i "$bridge" -j ACCEPT
             sudo ip6tables -I DOCKER-USER -o "$bridge" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-            set -e
-          done
-        fi
+          fi
+        done


### PR DESCRIPTION
`if sudo iptables -L DOCKER-USER; then` does 2 things:

1. detect if `iptables` is available
2. check if the `DOCKER-USER` chain exists