### PR TITLE
feat: enable KVM on Github Actions runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Enable KVM
+      run: |
+        # See: https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        
 
     - name: Install/refresh LXD snap
       shell: bash


### PR DESCRIPTION
This change ensures that KVM is enabled on Github Actions runners, which in turn makes LXD VMs usable.

This feature was documented some time ago on Github's blog, and is used in a fair few other actions. I've personally relied on it for some time in other workflows.